### PR TITLE
Create empty post with a complete header

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ gem "jekyll", "~> 3.0"
 gem "susy"
 gem "bourbon"
 gem "pdfkit"
+gem "nokogiri", "~> 1.6"
 
 group :jekyll_plugins do
   gem "jekyll-rdfa", "~> 0.0.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,6 +95,7 @@ DEPENDENCIES
   jekyll (~> 3.0)
   jekyll-babel
   jekyll-rdfa (~> 0.0.3)
+  nokogiri (~> 1.6)
   pdfkit
   susy
 

--- a/Rakefile
+++ b/Rakefile
@@ -75,11 +75,13 @@ task :post, [:title, :author, :post_title] do |t, args|
   worldcat = "http://www.worldcat.org/oclc/#{wc_id}"
 
   header = {
-    "title"    => post_title,
-    "date"     => today,
-    "author"   => author_info,
-    "resource" => worldcat,
-    "typeof"   => "Work"
+    "title"      => post_title,
+    "date"       => today,
+    "layout"     => "book",
+    "categories" => "book",
+    "author"     => author_info,
+    "resource"   => worldcat,
+    "typeof"     => "Work"
   }
 
   output_file = "_posts/#{today.strftime('%Y-%m-%d')}-#{slug}.md"


### PR DESCRIPTION
I wrote a utility like this for my site and found it helpful, and since I'd already done the hard part, thought I'd port it to your site.

Basically, you can create an empty post file from the command line based on an author and book. The task goes out and pulls down the author information from [VIAF](http://viaf.org/) and the book ID from [WorldCat](http://www.worldcat.org/).

So if you enter this on the command line (including the quotes):

```bash
rake "post[Man's Search for Meaning,Viktor Frankl]"
```

You'll get a file written to `_posts/2017-02-13-man-s-search-for-meaning.md` with these contents:

```markdown
---
title: Man's Search for Meaning
date: 2017-02-13
author:
  name: Viktor Frankl
  resource: http://viaf.org/viaf/95178598
  typeof: Person
resource: http://www.worldcat.org/oclc/895615338
typeof: Work
---

```

Let me know if you have any questions.